### PR TITLE
Add importlib_metadata>=4 constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
     - pyflyte=flytekit.clis.sdk_in_container.pyflyte:main
     - flyte-cli=flytekit.clis.flyte_cli.main:_flyte_cli
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - docstring_parser >=0.9.0
     - flyteidl >=0.21.4
     - grpcio >=1.3.0,<2.0
+    - importlib_metadata>=4
     - keyring >=18.0.1
     - marshmallow-jsonschema >=0.12.0
     - natsort >=7.0.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - docstring_parser >=0.9.0
     - flyteidl >=0.21.4
     - grpcio >=1.3.0,<2.0
-    - importlib_metadata>=4
+    - importlib_metadata >=4
     - keyring >=18.0.1
     - marshmallow-jsonschema >=0.12.0
     - natsort >=7.0.1


### PR DESCRIPTION
As the title suggests, a quick PR to pin the minimum `importlib_metadata` to >=4. Closes #4 
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
