### PR TITLE
Pin pip <24.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
 
 requirements:
   host:
-    - pip <=24.0
+    - pip
     - python >=3.8, <3.13
   run:
     - numpy <2
@@ -80,7 +80,7 @@ test:
     - flyte-cli --help
     - pyflyte run example.py hello_world_wf --name foobar
   requires:
-    - pip
+    - pip <24.2
 
 about:
   home: https://github.com/flyteorg/flytekit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
 
 requirements:
   host:
-    - pip <= 24.0
+    - pip <=24.0
     - python >=3.8, <3.13
   run:
     - numpy <2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "flytekit" %}
-{% set version = "1.13.1" %}
+{% set version = "1.13.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/flytekit-{{ version }}.tar.gz
-  sha256: 8987da685f6cab337ddea59ee7bb88062638be1e4a9880ab703dcc050bee189e
+  sha256: c25ccf7494efa10cf5eb65a709b514de839ffdb355f18f9682ff04adf62a02a4
 
 build:
   entry_points:
@@ -22,7 +22,7 @@ build:
 
 requirements:
   host:
-    - pip
+    - pip <24.2
     - python >=3.8, <3.13
   run:
     - numpy <2
@@ -36,7 +36,7 @@ requirements:
     - diskcache >=5.2.1
     - docker-py >=4.0.0
     - docstring_parser >=0.9.0
-    - flyteidl >=1.12.0
+    - flyteidl >=1.13.1
     - fsspec >=2023.3.0
     - gcsfs >=2023.3.0
     - googleapis-common-protos >=1.57

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
 
 requirements:
   host:
-    - pip <24.2
+    - pip <= 24.0
     - python >=3.8, <3.13
   run:
     - numpy <2


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

As explained in https://matrix.to/#/!SOyumkgPRWoXfQYIFH:matrix.org/$172303892130tnUIA:gitter.im?via=matrix.org&via=gitter.im&via=t2bot.io, we're seeing build failures because in flytekit because one of the downstream dependencies has invalid compatibility tags. This is the error:
```
stringcase 1.2.0 is not supported on this platform
```

According to the conda gitter, this would be fixed if we could publish a new version of the `stringcase` feedstock. I started https://github.com/conda-forge/stringcase-feedstock/pull/2, but to unblock the flytekit feedstock, I'm pinning `pip < 0.24.2`.