### PR TITLE
Allow for python 3.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ test:
     - pyflyte run example.py hello_world_wf --inputs-file example-inputs.json
   requires:
     - pip <24.2
-    - python ={{ python_min }}
+    - python {{ python_min }}
 
 about:
   home: https://github.com/flyteorg/flytekit


### PR DESCRIPTION
With this PR, flytekit can be installed with Python 3.12.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
